### PR TITLE
feat: implement resume download functionality (#11)

### DIFF
--- a/src/app/sections/Footer.tsx
+++ b/src/app/sections/Footer.tsx
@@ -1,4 +1,14 @@
-import { LuGithub, LuLinkedin, LuMail } from "react-icons/lu";
+import {
+  LuGithub,
+  LuLinkedin,
+  LuMail,
+  LuFileText,
+  LuUser,
+  LuZap,
+  LuCode,
+  LuBriefcase,
+  LuMailOpen,
+} from "react-icons/lu";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
@@ -23,41 +33,56 @@ export default function Footer() {
               <li>
                 <a
                   href="#about"
-                  className="transition-colors hover:text-cyan-400"
+                  className="flex items-center transition-colors hover:text-cyan-400"
                 >
+                  <LuUser size={16} className="mr-2" />
                   About
                 </a>
               </li>
               <li>
                 <a
                   href="#skills"
-                  className="transition-colors hover:text-cyan-400"
+                  className="flex items-center transition-colors hover:text-cyan-400"
                 >
+                  <LuZap size={16} className="mr-2" />
                   Skills
                 </a>
               </li>
               <li>
                 <a
                   href="#projects"
-                  className="transition-colors hover:text-cyan-400"
+                  className="flex items-center transition-colors hover:text-cyan-400"
                 >
+                  <LuCode size={16} className="mr-2" />
                   Projects
                 </a>
               </li>
               <li>
                 <a
                   href="#experience"
-                  className="transition-colors hover:text-cyan-400"
+                  className="flex items-center transition-colors hover:text-cyan-400"
                 >
+                  <LuBriefcase size={16} className="mr-2" />
                   Experience
                 </a>
               </li>
               <li>
                 <a
                   href="#contact"
-                  className="transition-colors hover:text-cyan-400"
+                  className="flex items-center transition-colors hover:text-cyan-400"
                 >
+                  <LuMailOpen size={16} className="mr-2" />
                   Contact
+                </a>
+              </li>
+              <li>
+                <a
+                  href="/resume.pdf"
+                  download
+                  className="flex items-center transition-colors hover:text-cyan-400"
+                >
+                  <LuFileText size={16} className="mr-2" />
+                  Download Resume
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
### Summary
This PR implements the core functionality to allow users to download the Resume/CV file directly from the portfolio interface.

### Implemented Changes
- Added the "Download Resume" link/Call-to-Action (CTA) in the **Hero Section** of the portfolio.
- Integrated the "Download Resume" link into the **Footer Section** for consistent access across pages.
- Configured the link to point to the placeholder PDF file located at `/public/resume.pdf`.
- Used the HTML `download` attribute on the link element to ensure the file is downloaded directly rather than navigated to.

### Preview
- A new "Download Resume" button/link is visible on the main page hero and in the site footer.
- Clicking the link/button immediately initiates the download of the `resume.pdf` file.
- The link correctly handles the file path regardless of the user's current route.

### Related Issues
Closes: #11